### PR TITLE
Mail Encryption > Select options tls/ssl/null

### DIFF
--- a/js/admin/dist/extension.js
+++ b/js/admin/dist/extension.js
@@ -59,12 +59,27 @@ System.register('vingle/configure/smtp/components/ConfigureSMTPSettingModal', ['
                                 null,
                                 ' Mail Encryption '
                             ),
-                            m('input', {
-                                className: 'FormControl',
-                                bidi: this.setting('mail_encryption')
-                            }),
-                            'null'
-                        ), m(
+                            m(
+                                'select', 
+                                { className: 'FormControl', bidi: this.setting('mail_encryption') },
+                                m(
+                                    'option',
+                                    { value: 'tls' },
+                                    'tls'
+                                ),
+                                m(
+                                    'option',
+                                    { value: 'ssl' },
+                                    'ssl'
+                                ),
+                                m(
+                                    'option',
+                                    { value: 'null' },
+                                    'null'
+                                )
+                            ),
+                            'tls'
+                          ), m(
                             'div',
                             { className: 'Form-group' },
                             m(

--- a/js/admin/src/components/ConfigureSMTPSettingModal.js
+++ b/js/admin/src/components/ConfigureSMTPSettingModal.js
@@ -23,11 +23,12 @@ export default class ConfigureSMTPSettingModal extends SettingsModal {
 
             <div className = "Form-group">
                 <label> Mail Encryption </label>
-                <input
-                    className = "FormControl"
-                    bidi = {this.setting('mail_encryption')}
-                />
-                null
+                <select className = "FormControl" bidi = {this.setting('mail_encryption')}>
+                    <option value='tls'>tls</option>
+                    <option value='ssl'>ssl</option>
+                    <option value='null'>null</option>
+                </select>
+                tls
             </div>,
 
             <div className = "Form-group">


### PR DESCRIPTION
Hi,

Usually, if Flarum users don't see the available options tls/ssl/null, they could be wrong and write 'starttls' or 'TLS' or 'SSL' in uppercase, and it won't work. So, it's better to add this code to be able to choose between the available options.

Thanks!
